### PR TITLE
Changed Cmake Minimum Version to 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 ##
 ################################################################################
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 4.0)
 project(gcem)
 
 set(GCEM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)


### PR DESCRIPTION
Cmake Versions less than 3.5 have just been deprecated and less than 3.10 will soon be deprecated.